### PR TITLE
Replace arrow function

### DIFF
--- a/src/system-register-loader.js
+++ b/src/system-register-loader.js
@@ -44,7 +44,7 @@ SystemRegisterLoader.prototype.instantiate = function(key, metadata) {
 
   return new Promise(function(resolve, reject) {
     if (isNode)
-      Promise.resolve(fs || (fs = typeof require !== 'undefined' ? require('fs') : loader.import('fs').then(m => m.default)))
+      Promise.resolve(fs || (fs = typeof require !== 'undefined' ? require('fs') : loader.import('fs').then(function(m){ return m.default })))
       .then(function(fs) {
         fs.readFile(fileUrlToPath(key), function(err, source) {
           if (err)


### PR DESCRIPTION
This solitary piece of ES6 prevents the file being compressed by standard UglifyJS, so I'd suggest removing it.

The other change was done auto by my editor :-)

Are you planning on releasing the dist/compressed version of this on jspm registry so people can use that rather than install their own copy?
